### PR TITLE
Add --user option to create user namespace

### DIFF
--- a/verify.py
+++ b/verify.py
@@ -178,6 +178,8 @@ def parse_args():
     global g_verbose
     import argparse
     ap = argparse.ArgumentParser()
+    ap.add_argument('-U', '--user', action='store_true',
+            help="Create new user namespace")
     ap.add_argument('-v', '--verbose', action='store_true',
             help="Verbose output")
     args = ap.parse_args()
@@ -192,6 +194,9 @@ def main():
     s1 = snapshot()
 
     flags = clone.CLONE_NEWNET
+    if args.user:
+        flags |= clone.CLONE_NEWUSER
+
     clone.clone_call(do_netns_play, flags)
 
     s2 = snapshot()


### PR DESCRIPTION
This adds a `-U`/`--user` option which uses `CLONE_NEWUSER` to create a new *user namespace*, which  would avoid the need to run as root.

However, it is incomplete because it does not set any uid/gid mappings, causing this bad behavior due to invalid uid/gid:
```
/proc/sys/net/ipv4/ping_group_range: 65534	65534
  ->  65535 65535
Child function raised exception:
OSError: [Errno 22] Invalid argument
```